### PR TITLE
Add support for ssh server fingerprinting

### DIFF
--- a/README-server.md
+++ b/README-server.md
@@ -68,7 +68,7 @@ ssh-keyscan -p <port> <host>
 
 Or to automate the fetching of the value:
 ```
-ssh-keyscan -p 20666 -t ssh-ed25519 noshare.0x77.net | tail -1 | awk '{print $2 " " $3}'
+ssh-keyscan -p <port> -t ssh-ed25519 <host> | tail -1 | awk '{print $2 " " $3}'
 ```
 
 # caveats / improvements

--- a/README-server.md
+++ b/README-server.md
@@ -46,6 +46,31 @@ variables or by hacking/hard coding the `server.sh` script:
 * `NOSHARE_PORT` - the incoming port for clients to connect to (default = 20666)
 * `NOSHARE_KEYS_DIR` - where the directory of ssh pubkeys are found (default = `keys` dir peer of `server.sh`)
 
+# your users
+
+There are 2 or 3 things then to give to your users:
+
+* host 
+* port
+* ssh fingerprint
+
+
+The ssh fingerprint helps protect against "man in the middle" (MITM) attacks.
+It sucks with docker tho because if you restart a container then the 
+fingerprint changes.
+
+The `ssh-keyscan` tool is useful for getting server fingerprints.
+
+Simply run:
+```
+ssh-keyscan -p <port> <host>
+```
+
+Or to automate the fetching of the value:
+```
+ssh-keyscan -p 20666 -t ssh-ed25519 noshare.0x77.net | tail -1 | awk '{print $2 " " $3}'
+```
+
 # caveats / improvements
 
 * the modified keys dir is not configurable and requires the `KEYS_DIR` to be writable

--- a/README-server.md
+++ b/README-server.md
@@ -14,14 +14,62 @@ authorized users.
 Please note: as a server owner, you may pay for bandwidth. Your server consumes
 (send/receive) every byte transferred between peers.
 
-# running
+# setup
 
 First, copy the `server.sh` and `prefix` files somewhere.
 
+```
+$ git clone https://github.com/breedx2/noshare.git
+$ mkdir server
+$ cp noshare/server.sh server/
+$ cp noshare/prefix server/
+$ cd server
+```
+
+## user ssh keys
+
 Every user that wants to use the `noshare` will have to supply you with
 an ssh pubkey. Put all of those separate pubkey files into a directory named `keys`
-next to the `server.sh` script. After you do this it'll look something like:
+next to the `server.sh` script. 
 
+```
+$ mkdir keys
+$ cp /users/user1.pub keys/
+$ cp /users/user2.pub keys/
+...
+$ cp /users/whatever.pub keys/
+```
+
+You can add keys later, but will need to restart the server after each addition.
+
+## hostkeys
+
+This step is optional, but **highly encouraged**. If you do not specify hostkeys,
+you users will need to reconfigure the server fingerprint every time the 
+docker container restarts, or will need to run without host key checking
+enabled (this leaves them vulnerable to MITM attacks).
+
+Every ssh server has a set of host keys that are used to securely identify
+a server instance. If you do not provide your own, new ones will be created
+each time the container is started. Let's create some.
+
+```
+$ mkdir -p /tmp/keys/ssh/etc
+$ ssh-keygen -A -f /tmp/keys
+$ mkdir ssh_host_keys
+$ cp /tmp/keys/ssh/etc/* ssh_host_keys/
+$ rm -rf /tmp/keys
+```
+
+By default, `server.sh` will use the `ssh_host_keys` dir in the same directory
+as the `server.sh` script itself, but you can override it by setting the 
+`NOSHARE_HOST_KEYS_DIR` env var.
+
+
+# running
+
+Once your setup is complete, you should have a directory that looks
+similar to this:
 
 ```
 - server.sh
@@ -30,13 +78,20 @@ next to the `server.sh` script. After you do this it'll look something like:
    +---- user1.pub
    +---- user2.pub
    +---- whatever.pub
+- ssh_host_keys/
+   +---- ssh_host_ed25519_key
+   +---- ssh_host_ed25519_key.pub
+   +---- (others)
 ```
 
-Then run:
+Now that your directory is set up, you can just run the script:
 
 ```
-./server.sh
+$ ./server.sh
 ```
+
+Note: This script does some preprocessing of the user ssh keys to restrict
+some settings and to allow a tunnel to be created to localhost only.
 
 ## config
 
@@ -44,7 +99,8 @@ There are a few things that can be customized via environment
 variables or by hacking/hard coding the `server.sh` script:
 
 * `NOSHARE_PORT` - the incoming port for clients to connect to (default = 20666)
-* `NOSHARE_KEYS_DIR` - where the directory of ssh pubkeys are found (default = `keys` dir peer of `server.sh`)
+* `NOSHARE_KEYS_DIR` - the directory of user ssh pubkeys (default = `keys` dir peer of `server.sh`)
+* `NOSHARE_HOST_KEYS_DIR` - the directory of server keys (default = `ssh_host_keys` in dir peer of `server.sh` or recreated on container start) 
 
 # your users
 
@@ -52,23 +108,25 @@ There are 2 or 3 things then to give to your users:
 
 * host 
 * port
-* ssh fingerprint
+* ssh fingerprint (optional)
 
+## server ssh fingerprint
 
 The ssh fingerprint helps protect against "man in the middle" (MITM) attacks.
-It sucks with docker tho because if you restart a container then the 
-fingerprint changes.
+Unless you have provided the `NOSHARE_HOST_KEYS_DIR` env var or have the `ssh_host_keys`
+directory populated with keys, new server keys will be generated each time you
+start the docker container. This is not ideal.
 
 The `ssh-keyscan` tool is useful for getting server fingerprints.
 
 Simply run:
 ```
-ssh-keyscan -p <port> <host>
+ssh-keyscan -p <port> -t ssh-ed25519 <host>
 ```
 
 Or to automate the fetching of the value:
 ```
-ssh-keyscan -p <port> -t ssh-ed25519 <host> | tail -1 | awk '{print $2 " " $3}'
+ssh-keyscan -p <port> -t ssh-ed25519 <host> 2>&1 | tail -1 | awk '{print $2 " " $3}'
 ```
 
 # caveats / improvements

--- a/README.md
+++ b/README.md
@@ -24,11 +24,16 @@ It looks like this:
 
 # client quickstart
 
+The noshare client can both _offer_ files and _receive_ files.
+
 You must give your server admin your public ssh key (below).
 
 Your server/admin must give you:
 * a hostname or ip address
 * a port (or "default" which is 20666)
+
+And optionally:
+* server ssh fingerprint
 
 ## keygen
 
@@ -67,11 +72,16 @@ Don't forget to `chmod 755 /path/to/noshare`.
 ## config
 
 Now that you've got the client available, you need to do a one-time configuration.
-You can safely skip this and it'll prompt you the firs time you offer or
+You can safely skip this and it'll prompt you the first time you offer or
 receive.
 
 Run `noshare config` and enter the host and port that your admin gave you,
-and the path to the private key corresponding to the pubkey you gave to your admin..
+and the path to the private key corresponding to the pubkey you gave to your admin.
+
+If your admin gave you an ssh server hostkey, you can add that as well, otherwise
+the config step will probe for it. It's a good idea to verify that the probed 
+value matches the true server hostkey fingerprint (check with the admin if unsure).
+
 The result will be saved in `~/.noshare` and looks like this:
 
 ```
@@ -79,6 +89,7 @@ The result will be saved in `~/.noshare` and looks like this:
 host = your.example.com
 port = 20666
 keyfile = /home/user/.ssh/noshare
+fingerprint = ssh-ed25519 ABCDC3NzaC1lZDI1NTE5AAAdIJB8pG9d87RdbLBXKpD7tSMKACL2gbpDiCfX123123123
 ```
 
 ## offer
@@ -140,9 +151,6 @@ In order to keep things moderately simple, corners are cut. In the interest
 of disclosure, some obvious problems are listed here. These should probably
 turn into issues.
 
-* server host key checking -- Straight-up disabled. yup. sorry. It's convenient,
-  but insecure and it should be improved. This means someone could redirect dns
-  and intercept/mitm traffic.
 * multiple servers -- for simplicity, not supported.
 * one-shot -- it's convenient but kinda stupid that files are one-shot, and
   maybe there should be a way to keep an offer open/alive for some time or number

--- a/noshare.py
+++ b/noshare.py
@@ -227,8 +227,7 @@ class Tunnel:
             await server.serve_forever()
         except asyncio.exceptions.CancelledError:
             print('exiting.')
-        ssh.close()
-        ssh.wait(quiet=True)
+        self._cleanup(ssh)
 
     async def receive(self, id):
         print("Setting up ssh tunnel...")
@@ -239,8 +238,13 @@ class Tunnel:
         # print("DEBUG: tunnel local {} to remote {}".format(local_port, remote_port))
         receiver = FileReceiver(id, local_port)
         await receiver.receive()
+        self._cleanup(ssh)
+
+    def _cleanup(self, ssh):
         ssh.close()
         ssh.wait(quiet=True)
+        if config.tempKnownHostsFile:
+            os.remove(config.tempKnownHostsFile)
 
     def _random_port(self):
         return random.randint(1025, 65000)

--- a/noshare.py
+++ b/noshare.py
@@ -115,15 +115,6 @@ class FileReceiver:
 
     async def connect(self):
         return await try_connect(self.local_port)
-        # tries = 50
-        # while tries > 0:
-        #     try:
-        #         reader, writer = await asyncio.open_connection('127.0.0.1', self.local_port)
-        #         return reader,writer
-        #     except:
-        #         tries = tries - 1
-        #         time.sleep(0.1)
-        # raise Exception('Failed to connect (tried 50 times)')
 
     async def handshake(self, reader, writer):
         writer.write("{}\n".format(self.id).encode())

--- a/noshare.py
+++ b/noshare.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import tempfile
 import uuid
-import socket
 
 DEFAULT_NOSHARE_PORT = 20666
 DEFAULT_SSHKEY = '~/.ssh/id_rsa'
@@ -318,42 +317,9 @@ class Ssh:
             "-i", self.config.keyfile,
             "app@" + self.config.remoteHost
         ]
-        # print(cmd)
         self.child = subprocess.Popen(cmd, 
             stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, 
             universal_newlines=True)
-        # rc = self._verify_connection()
-        # if not rc:
-        #     raise Exception('Error opening ssh tunnel. Aborting.')
-        # rc = self.child.poll()
-        # print(rc)
-        # print("ssh tunnel established (pid={})".format(self.child.pid))
-
-
-    # def _verify_connection(self):
-    #     try:
-    #         out,errs = self.child.communicate(timeout=3)
-    #         if errs:
-    #             print(errs)
-    #             return False
-    #     except subprocess.TimeoutExpired:
-    #         print('timeout expired (probably a good thing!)')    
-    #         rc = self.child.poll()
-    #         if rc:
-    #             return False
-    #     return True
-
-    # def _verify_connection(self):
-    #     if self.offer_side:
-    #         sleep(2) 
-    #         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    #         sock.settimeout(2)
-    #         result = sock.connect_ex(('127.0.0.1', self.local_port))
-    #         if result == 0:
-    #             print('port OPEN')
-    #         else:
-    #             print('port CLOSED, connect_ex returned: '+str(result))
-    #         sock.close()
 
     def close(self):
         self.child.terminate()

--- a/noshare.py
+++ b/noshare.py
@@ -297,10 +297,12 @@ class Ssh:
         return "{}:localhost:{}".format(self.local_port, self.remote_port)
 
 class Config:
-    def __init__(self, remoteHost, remotePort = DEFAULT_NOSHARE_PORT, keyfile = DEFAULT_SSHKEY, tempKnownHostsFile = None):
+    def __init__(self, remoteHost, remotePort = DEFAULT_NOSHARE_PORT, keyfile = DEFAULT_SSHKEY, 
+                fingerprint = None, tempKnownHostsFile = None):
         self.remoteHost = remoteHost
         self.remotePort = remotePort
         self.keyfile = keyfile
+        self.fingerprint = fingerprint
         self.tempKnownHostsFile = tempKnownHostsFile
 
     @staticmethod
@@ -319,7 +321,8 @@ class Config:
         if not port: port = DEFAULT_NOSHARE_PORT
         keyfile = input('ssh key file [{}]: '.format(DEFAULT_SSHKEY))
         if not keyfile: keyfile = DEFAULT_SSHKEY
-        return Config(host, port, keyfile)
+        fingerprint = input('ssh host fingerprint [None]: ')
+        return Config(host, port, keyfile, fingerprint)
 
     @staticmethod
     def read():
@@ -333,7 +336,7 @@ class Config:
         else:
             print('\u001b[31m** \u001b[33mWarning: No server fingerprint found in config file. Vulnerable to MITM.\033[0m')
             tempKnownHostsFile = None
-        return Config(ns['host'], ns['port'], ns['keyfile'], tempKnownHostsFile)
+        return Config(ns['host'], ns['port'], ns['keyfile'], fingerprint, tempKnownHostsFile)
 
     @staticmethod
     def _write_temp_known_hosts(host, port, fingerprint):
@@ -345,7 +348,8 @@ class Config:
     def write(self):
         config = ConfigParser()
         config['noshare'] = {
-            "host": self.remoteHost, "port": self.remotePort, "keyfile": self.keyfile
+            'host': self.remoteHost, 'port': self.remotePort, 'keyfile': self.keyfile, 
+            'fingerprint': self.fingerprint
         }
         with open(Config.filename(), 'w') as out:
             config.write(out)
@@ -402,6 +406,7 @@ else:
     print("\n\u001b[33;1mNot yet configured. Let's get you set up.\033[0m\n")
     config = Config.prompt()
     config.write()
+    config = Config.read()
     print("Config saved to {}".format(Config.filename()))
 
 # If the argument exists as a file, assume offer

--- a/server.sh
+++ b/server.sh
@@ -14,6 +14,17 @@ if [ "${NOSHARE_KEYS_DIR}" == "" ] ; then
 	echo "Defaulting keys dir to ${NOSHARE_KEYS_DIR}"
 fi
 
+if [ "${NOSHARE_HOST_KEYS_DIR}" == "" ] ; then
+	if [ -d "${MYDIR}/ssh_host_keys" ] ; then
+		echo "Found ${MYDIR}/ssh_host_keys, using as server ssh host keys"
+		NOSHARE_HOST_KEYS_DIR="${MYDIR}/ssh_host_keys"
+	else
+		echo "NOSHARE_HOST_KEYS_DIR not specified and default not found"
+		echo "New host keys will be generated on container start."
+		echo "* Users may need to update their server fingerprint!"
+	fi
+fi
+
 MOUNT_DIR="${NOSHARE_KEYS_DIR}/mounted"
 
 rm -rf "${MOUNT_DIR}"
@@ -29,9 +40,15 @@ for f in $(find "${NOSHARE_KEYS_DIR}" -type f -name '*.pub') ; do
 	cat $f >> "${MOUNT_DIR}/$FN"
 done
 
+if [ "${NOSHARE_HOST_KEYS_DIR}" != "" ] ; then
+	HOSTKEYS_PREFIX="-v"
+	HOSTKEYS_PART="${NOSHARE_HOST_KEYS_DIR}:/config/ssh_host_keys"
+fi
+
 docker run -d --name noshare --restart=on-failure:5 \
         -p ${NOSHARE_PORT}:2222 \
         -v "${MOUNT_DIR}:/etc/pubkeys" \
+		"${HOSTKEYS_PREFIX}" "${HOSTKEYS_PART}" \
         -e DOCKER_MODS=linuxserver/mods:openssh-server-ssh-tunnel \
         -e PUBLIC_KEY_DIR=/etc/pubkeys \
         -e USER_NAME=app \


### PR DESCRIPTION
This is an important feature. Previous version always disabled host fingerprint checking, which made `noshare` vulnerable to MITM attacks (unlikely for casual use, but still concerning).

This change now allows the spawned ssh process to user strict fingerprint checking. It does this in a way that is backwards compatible with existing `~/.noshare` configs -- however, it will log a warning if the config does not contain a fingerprint.

Because there are new failure modes for the ssh tunnel (such as the host key changing), I also used this as an opportunity to improve the tunnel checking. Previously, some failure modes would allow the "offer"ing side to create an offer ID even thought the tunnel was nonfunctional. We make sure we can connect to our opened tunnel port before even showing the offer ID to the user.

In the guided configuration, the user is also now prompted for the ssh host fingerprint, and if not provided it will be automatically probed with `ssh-keyscan`.

Now that hostkey fingerprints are supported by the clients, we needed to make some improvements to the server side. Previously, each time the ssh container was restarted the server keys were regenerated. This could cause all clients to immediately show the server as invalid and log a verification error, rendering the app unusable. To mitigate this, we now have a directory containing the server host keys that gets bind mounted into the docker container....so there are consistent keys being used across container upgrades/restarts and the fingerprints shouldn't have to change.