### PR TITLE
remove prerequisite

### DIFF
--- a/README-server.md
+++ b/README-server.md
@@ -17,17 +17,6 @@ Please note: as a server owner, you may pay for bandwidth. Your server consumes
 
 # setup
 
-## prerequisites
-
-To run the server, it is expected that you have the following
-software installed:
-
-* docker
-* bash
-* common unix commandline tools (find, basename, tail, etc)
-
-## prepare
-
 First, copy the `server.sh` and `prefix` files somewhere.
 
 ```


### PR DESCRIPTION
I don't think that was necessary, you were right that a requirement to start reading the README is "get that this is a docker project running on a dev linux box"
