### PR TITLE
Correct length

### DIFF
--- a/README-server.md
+++ b/README-server.md
@@ -17,7 +17,7 @@ Please note: as a server owner, you may pay for bandwidth. Your server consumes
 
 # setup
 
-## prerequesites
+## prerequisites
 
 To run the server, it is expected that you have the following
 software installed:

--- a/README-server.md
+++ b/README-server.md
@@ -14,7 +14,19 @@ authorized users.
 Please note: as a server owner, you may pay for bandwidth. Your server consumes
 (send/receive) every byte transferred between peers.
 
+
 # setup
+
+## prerequesites
+
+To run the server, it is expected that you have the following
+software installed:
+
+* docker
+* bash
+* common unix commandline tools (find, basename, tail, etc)
+
+## prepare
 
 First, copy the `server.sh` and `prefix` files somewhere.
 

--- a/noshare.py
+++ b/noshare.py
@@ -148,12 +148,15 @@ class Progress:
         self.last_display = 0.0
         self.spin = ['/', '-', '\\', '|']
         self.last_str = ''
+        self.ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
     def show(self, remaining, force=False):
         now = datetime.now().timestamp()
         if not force and now - self.last_display < 0.5:
             return
-        print(''.ljust(len(self.last_str), '\b'), end='', flush=True)
+        
+        stripped = self.ansi_escape.sub('', self.last_str)
+        print(''.ljust(len(stripped), '\b'), end='', flush=True)
 
         elapsed = now - self.start_time
         transferred = self.size - remaining


### PR DESCRIPTION
Resolves #8 

The length being used for backspacing was not considering the control codes, so it was printing more backspaces than necessary. On some terminals, this would cause the cursor to go to the previous line and corrupt the display.

The control codes are now stripped when computing the length to backspace.